### PR TITLE
Fix race condition in `free` and `occupied`

### DIFF
--- a/portend.py
+++ b/portend.py
@@ -111,16 +111,16 @@ def free(host, port, timeout=float('Inf')):
 
 	timer = timing.Timer(timeout)
 
-	while not timer.expired():
+	while True:
 		try:
 			# Expect a free port, so use a small timeout
 			Checker(timeout=0.1).assert_free(host, port)
 			return
 		except PortNotFree:
+			if timer.expired():
+				raise Timeout("Port {port} not free on {host}.".format(**locals()))
 			# Politely wait.
 			time.sleep(0.1)
-
-	raise Timeout("Port {port} not free on {host}.".format(**locals()))
 
 
 wait_for_free_port = free
@@ -145,16 +145,16 @@ def occupied(host, port, timeout=float('Inf')):
 
 	timer = timing.Timer(timeout)
 
-	while not timer.expired():
+	while True:
 		try:
 			Checker(timeout=.5).assert_free(host, port)
+			if timer.expired():
+				raise Timeout("Port {port} not bound on {host}.".format(**locals()))
 			# Politely wait
 			time.sleep(0.1)
 		except PortNotFree:
 			# port is occupied
 			return
-
-	raise Timeout("Port {port} not bound on {host}.".format(**locals()))
 
 
 wait_for_occupied_port = occupied

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ testing =
 	pytest >= 3.5, !=3.7.3
 	pytest-checkdocs
 	pytest-flake8
+	pytest-mock
 
 	# local
 

--- a/test_portend.py
+++ b/test_portend.py
@@ -2,6 +2,7 @@ import socket
 import contextlib
 
 import pytest
+from tempora import timing
 
 import portend
 
@@ -46,6 +47,11 @@ def nonlistening_addr(request):
 	return sa
 
 
+@pytest.fixture
+def immediate_timeout(mocker):
+	mocker.patch.object(timing.Timer, 'expired').return_value(True)
+
+
 class TestChecker:
 	def test_check_port_listening(self, listening_addr):
 		with pytest.raises(portend.PortNotFree):
@@ -53,3 +59,13 @@ class TestChecker:
 
 	def test_check_port_nonlistening(self, nonlistening_addr):
 		portend.Checker().assert_free(nonlistening_addr)
+
+	def test_free_with_immediate_timeout(
+		self, nonlistening_addr, immediate_timeout):
+		host, port = nonlistening_addr[:2]
+		portend.free(host, port, timeout=1.0)
+
+	def test_occupied_with_immediate_timeout(
+		self, listening_addr, immediate_timeout):
+		host, port = listening_addr[:2]
+		portend.occupied(host, port, timeout=1.0)


### PR DESCRIPTION
Fixes #10.