### PR TITLE
Introduce portend.__version__

### DIFF
--- a/portend.py
+++ b/portend.py
@@ -6,6 +6,8 @@ A simple library for managing the availability of ports.
 
 from __future__ import print_function, division
 
+__version__ = "2.6"
+
 import time
 import socket
 import argparse


### PR DESCRIPTION
Just like other python packages: a `__version__` to see/check the package version

```
$ python3 -c "import portend; print(portend.__version__)"
2.6
```